### PR TITLE
Changing deref version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "chance": "^0.6.4",
-    "deref": "^0.2.6",
+    "deref": "0.2.6",
     "faker": "^2.1.2",
     "randexp": "^0.4.0"
   }


### PR DESCRIPTION
Versions after 0.2.6 of deref throws an exception when processing internal references. Forcing version 0.2.6