### PR TITLE
online demo link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # json-schema-faker online demo
 
+See [online demo](http://json-schema-faker.js.org/). The `gh-pages` (current) branch hosts this app.
+
 ## Development
 
-Use github pages on your private account (e.g. [this one](http://tkoomzaaskz.github.io/json-schema-faker/)) to see how the app is going to look like.
+Use [github pages](https://pages.github.com/) of your private github account (e.g. [this one](http://tkoomzaaskz.github.io/json-schema-faker/)) to see how the app is going to look like on production.
 
 This project is automated using [grunt](gruntjs.com). Run:
 


### PR DESCRIPTION
Just the link to the demo (`gh-pages` has a separate [README.md](README.md)).