### PR TITLE
Infer type when not present (when possible)

### DIFF
--- a/lib/util/traverse.js
+++ b/lib/util/traverse.js
@@ -4,6 +4,38 @@ var random = require('./random'),
     combine = require('./combine');
 
 var ParseError = require('./error');
+var inferredProperties = {
+  array: [
+    'additionalItems',
+    'items',
+    'maxItems',
+    'minItems',
+    'uniqueItems'
+  ],
+  integer: [
+    'exclusiveMaximum',
+    'exclusiveMinimum',
+    'maximum',
+    'minimum',
+    'multipleOf'
+  ],
+  object: [
+    'additionalProperties',
+    'dependencies',
+    'maxProperties',
+    'minProperties',
+    'patternProperties',
+    'properties',
+    'required'
+  ],
+  string: [
+    'maxLength',
+    'menlength',
+    'pattern'
+  ]
+};
+
+inferredProperties.number = inferredProperties.integer;
 
 function reduce(obj) {
   var mix = obj.allOf || obj.anyOf || obj.oneOf;
@@ -62,6 +94,25 @@ function traverse(obj, path) {
 
   if (Array.isArray(type)) {
     type = random.pick(type);
+  } else if (typeof type === 'undefined') {
+    // Attempt to infer the type
+    var typeProperties;
+
+    for (var key in inferredProperties) {
+      typeProperties = inferredProperties[key];
+
+      for (var i = 0; i < typeProperties.length; i++) {
+        if (typeof obj[typeProperties[i]] !== 'undefined') {
+          type = key;
+
+          break;
+        }
+      }
+
+      if (typeof type !== 'undefined') {
+        break;
+      }
+    }
   }
 
   if (typeof type === 'string') {

--- a/spec/core/types/arrays.json
+++ b/spec/core/types/arrays.json
@@ -98,6 +98,15 @@
           "additionalItems": false
         },
         "throws": "missing items for .+? in \\/"
+      },
+      {
+        "description": "should handle inferred type (when possible)",
+        "schema": {
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": "array"
       }
     ]
   }

--- a/spec/core/types/integers.json
+++ b/spec/core/types/integers.json
@@ -61,6 +61,13 @@
         "hasNot": ".",
         "type": "number",
         "valid": true
+      },
+      {
+        "description": "should handle inferred type (when possible)",
+        "schema": {
+          "maximum": 5
+        },
+        "type": "number"
       }
     ]
   }

--- a/spec/core/types/objects.json
+++ b/spec/core/types/objects.json
@@ -72,6 +72,15 @@
           "additionalProperties": false
         },
         "throws": "missing properties for .+? in \\/"
+      },
+      {
+        "description": "should handle inferred type (when possible)",
+        "schema": {
+          "properties": {
+            "name": { "type": "string" }
+          }
+        },
+        "type": "object"
       }
     ]
   }

--- a/spec/core/types/strings.json
+++ b/spec/core/types/strings.json
@@ -129,6 +129,13 @@
           "required": ["test"]
         },
         "throws": "unknown faker-generator for .+? in \\/properties\\/test"
+      },
+      {
+        "description": "should handle inferred type (when possible)",
+        "schema": {
+          "maxLength": 5
+        },
+        "type": "string"
       }
     ]
   }


### PR DESCRIPTION
I recently tried to take the [Swagger Petstore](http://petstore.swagger.io/v2/swagger.json) document and create a sample `Pet` _(#/definitions/Pet)_ instance using json-schema-faker.  Whenever I invoked json-schema-faker, instead of the expected `Pet` structure, I got the JSON Schema I provided to json-schema-faker back but its content had been faked.  To show you the input/output, here is an example:

**Sample Schema**
```js
{
  "required": [
    "name",
    "photoUrls"
  ],
  "properties": {
    "id": {
      "type": "integer",
      "format": "int64"
    },
    "category": {
      "properties": {
        "id": {
          "type": "integer",
          "format": "int64"
        },
        "name": {
          "type": "string"
        }
      },
      "xml": {
        "name": "Category"
      }
    },
    "name": {
      "type": "string",
      "example": "doggie"
    },
    "photoUrls": {
      "type": "array",
      "xml": {
        "name": "photoUrl",
        "wrapped": true
      },
      "items": {
        "type": "string"
      }
    },
    "tags": {
      "type": "array",
      "xml": {
        "name": "tag",
        "wrapped": true
      },
      "items": {
        "properties": {
          "id": {
            "type": "integer",
            "format": "int64"
          },
          "name": {
            "type": "string"
          }
        },
        "xml": {
          "name": "Tag"
        }
      }
    },
    "status": {
      "type": "string",
      "description": "pet status in the store",
      "enum": [
        "available",
        "pending",
        "sold"
      ]
    }
  },
  "xml": {
    "name": "Pet"
  }
}
```

**Sample Fake Data**

```js
{
  "required": [
    "name",
    "photoUrls"
  ],
  "properties": {
    "id": -72799149,
    "category": {
      "properties": {
        "id": 62682095,
        "name": "natus totam eos sed"
      },
      "xml": {
        "name": "Category"
      }
    },
    "name": "quo nihil et dolorem iste",
    "photoUrls": [
      "voluptatem recusandae quam et",
      "suscipit pariatur consectetur",
      "hic",
      "voluptatem illo in veritatis a",
      "est"
    ],
    "tags": [
      {
        "properties": {
          "id": 40984798,
          "name": "quibusdam amet"
        },
        "xml": {
          "name": "Tag"
        }
      }
    ],
    "status": "sold"
  },
  "xml": {
    "name": "Pet"
  },
  "id": "#"
}
```

After some digging, I found the reason was a missing `type` property on the complex objects.  Since JSON Schema does not require the `type` property to be set, I've created a pull request that allows json-schema-faker to infer missing type properties whenever the schema contains JSON Schema validation constraints on them.  Now this is not a guaranteed fix of course because it relies on the existence of optional properties but it does work when possible.

I would not be upset if you chose not to accept this and marked it _"Not my problem"_ but I figured I would at least try to see if it was useful to others than myself.  In the end, I was able to fix my need by just adding in the `type` properties and of course json-schema-faker produces the expected content.  My worry is that if Swagger and JSON Schema do not necessarily require `type` to be set and we have tooling that keys off of the `type`, we could possibly benefit from something like this to help when possible instead of just telling the end users that while what they have is valid, to get more accurate results they need to alter their document.