### PR TITLE
Always initializing primitives in traverse slows it down

### DIFF
--- a/lib/util/traverse.js
+++ b/lib/util/traverse.js
@@ -7,6 +7,8 @@ var ParseError = require('./error');
 
 var inferredType = require('./inferred');
 
+var primitives = null;
+
 function reduce(obj) {
   var mix = obj.allOf || obj.anyOf || obj.oneOf;
 
@@ -44,7 +46,9 @@ function reduce(obj) {
 }
 
 function traverse(obj, path) {
-  var primitives = require('./primitives');
+  if (primitives === null) {
+    primitives = require('./primitives');
+  }
 
   var copy = {};
 


### PR DESCRIPTION
We have to generate zillion of JSONs, and I have found that initializing `primitives` every time in `traverse.js` causes this slowness.

For testing I have used the [official example](https://github.com/pateketrueke/json-schema-faker#example-usage) with a big loop:

```javascript
for (var i = 0; i < 10000; i++) {
    var sample = jsf(schema);
}
```

With the original jsf it took more than 3 seconds:

```
$ time node jst_test.js

real  0m3.210s
user  0m3.168s
sys   0m0.060s
```

With lazy-but-not-always initialization the generation required less, than 1.5 seconds:

```
$ time node jst_test.js 

real   0m1.453s
user   0m1.432s
sys    0m0.032s
```
