### PR TITLE
Do not infer types for object property containers

### DIFF
--- a/lib/util/inferred.js
+++ b/lib/util/inferred.js
@@ -40,15 +40,20 @@ function mayHaveType(obj, props) {
 }
 
 module.exports = function(obj, path) {
-  // We have to short circuit these objects whose path ends with either of these two properties since they can have
-  // property names that match inferred property names (Issue 62)
-  if (['additionalProperties', 'properties'].indexOf(path[path.length - 1]) > -1) {
-    return;
-  } else {
-    for (var type in inferredProperties) {
-      if (mayHaveType(obj, inferredProperties[type])) {
-        return type;
-      }
+  // Do not attempt to infer properties named additionalProperties or properties containers.  The reason for this is
+  // that any property name within those containers that matches one of the properties used for inferring missing type
+  // values causes the container itself to get processed which leads to invalid output.  (Issue 62)
+  if (['additionalProperties', 'properties'].indexOf(path[path.length -1]) > -1) {
+    // The only way a container is encountered is if there is an odd number of path segments and the parent path
+    // segment is not either additionalProperties or properties.
+    if (path.length % 2 !== 0 || ['additionalProperties', 'properties'].indexOf(path[path.length - 2]) === -1) {
+      return;
+    }
+  }
+
+  for (var type in inferredProperties) {
+    if (mayHaveType(obj, inferredProperties[type])) {
+      return type;
     }
   }
 };

--- a/lib/util/inferred.js
+++ b/lib/util/inferred.js
@@ -39,10 +39,16 @@ function mayHaveType(obj, props) {
   }).length > 0;
 }
 
-module.exports = function(obj) {
-  for (var type in inferredProperties) {
-    if (mayHaveType(obj, inferredProperties[type])) {
-      return type;
+module.exports = function(obj, path) {
+  // We have to short circuit these objects whose path ends with either of these two properties since they can have
+  // property names that match inferred property names (Issue 62)
+  if (['additionalProperties', 'properties'].indexOf(path[path.length - 1]) > -1) {
+    return;
+  } else {
+    for (var type in inferredProperties) {
+      if (mayHaveType(obj, inferredProperties[type])) {
+        return type;
+      }
     }
   }
 };

--- a/lib/util/traverse.js
+++ b/lib/util/traverse.js
@@ -66,7 +66,7 @@ function traverse(obj, path) {
     type = random.pick(type);
   } else if (typeof type === 'undefined') {
     // Attempt to infer the type
-    type = inferredType(obj) || type;
+    type = inferredType(obj, path) || type;
   }
 
   if (typeof type === 'string') {

--- a/spec/core/types/arrays.json
+++ b/spec/core/types/arrays.json
@@ -109,16 +109,42 @@
         "type": "array"
       },
       {
-        "description": "should handle object properties named 'items' (Issue 62)",
+        "description": "should handle property name matching inferrable object properties (Issue 62)",
         "schema": {
           "id": "matches",
           "type": "object",
           "required": ["items"],
           "properties": {
             "items": {
-              "type": "array",
               "items": {
                 "type": "string"
+              },
+              "minItems": 1,
+              "maxItems": 10
+            }
+          }
+        },
+        "type": "object"
+      },
+      {
+        "description": "should handle nested property name matching inferrable object properties (Issue 62)",
+        "schema": {
+          "id": "matches",
+          "type": "object",
+          "required": ["items"],
+          "properties": {
+            "items": {
+              "items": {
+                "required": ["items"],
+                "properties": {
+                  "items": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 10
+                  }
+                }
               },
               "minItems": 1,
               "maxItems": 10

--- a/spec/core/types/arrays.json
+++ b/spec/core/types/arrays.json
@@ -107,6 +107,25 @@
           }
         },
         "type": "array"
+      },
+      {
+        "description": "should handle object properties named 'items' (Issue 62)",
+        "schema": {
+          "id": "matches",
+          "type": "object",
+          "required": ["items"],
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "maxItems": 10
+            }
+          }
+        },
+        "type": "object"
       }
     ]
   }


### PR DESCRIPTION
`additionalProperties` and `properties` are containers that themselves do not have a `type` property.  What use to happen is that whenever these containers were encountered, if any of the properties within those containers used the same name as those properties used to infer types, the container itself would have its type inferred and that would break the processing.

Fixes #62